### PR TITLE
Fixed install_requires in setup.py, added future for tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,11 +62,14 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules"],
     install_requires=[
          'oicmsg',
-         "Cherrypy",
+         "CherryPy",
          'cherrypy-cors >= 1.5'],
+    dependency_links = [
+         "https://github.com/IdentityPython/oicmsg/tarball/master#egg=oicmsg"],
     zip_safe=False,
     cmdclass={'test': PyTest},
     tests_require=[
         "pytest",
+        "future"
     ]
 )


### PR DESCRIPTION
Had some problems with setup.py. The fix:
* Cherrypy -> CherryPy
* added github dependency_links to install oicmsg
* added 'future' in test requirements since with python3.5 I got:
../venv/fedoidcmsg/lib/python3.5/site-packages/oicmsg-0.0.1-py3.5.egg/oicmsg/oic/__init__.py:4: in <module>
    from future.backports.urllib.parse import urlencode
E   ImportError: No module named 'future'